### PR TITLE
Use v3 of the rffsps

### DIFF
--- a/src/MimiRFFSPs.jl
+++ b/src/MimiRFFSPs.jl
@@ -9,9 +9,9 @@ include("components/RegionAggregatorSum.jl")
 
 function __init__()
     register(DataDep(
-        "rffsps_v2",
-        "RFF SPs prerelease version v2.",
-        "https://rffsps.s3.us-west-1.amazonaws.com/rffsps_v2.7z",
+        "rffsps_v3",
+        "RFF SPs prerelease version v3.",
+        "https://rffsps.s3.us-west-1.amazonaws.com/rffsps_v3.7z",
         post_fetch_method=unpack
     ))
 end

--- a/src/components/SPs.jl
+++ b/src/components/SPs.jl
@@ -86,7 +86,7 @@ end
         #   GDP in billions of $2005 USD
        
         # Load Feather File
-        t = Arrow.Table(joinpath(datadep"rffsps_v2", "pop_income", "rffsp_pop_income_run_$(p.id).feather"))
+        t = Arrow.Table(joinpath(datadep"rffsps_v3", "pop_income", "rffsp_pop_income_run_$(p.id).feather"))
         fill_socioeconomics!(t.Year, t.Country, t.Pop, t.GDP, v.population, v.gdp, country_lookup, p.start_year, p.end_year)
 
         for year in p.start_year:5:p.end_year-5, country in country_indices
@@ -112,7 +112,7 @@ end
         deathrate_trajectory_id = convert(Int64, g_datasets[:pop_trajectory_key][p.id])
         
         # Load Feather File
-        t = Arrow.Table(joinpath(datadep"rffsps_v2", "death_rates", "rffsp_death_rates_run_$(deathrate_trajectory_id).feather"))
+        t = Arrow.Table(joinpath(datadep"rffsps_v3", "death_rates", "rffsp_death_rates_run_$(deathrate_trajectory_id).feather"))
         fill_deathrates!(t.Year, t.ISO3, t.DeathRate, v.deathrate, country_lookup, p.start_year, p.end_year)
         # TODO could handle the repeating of years here instead of loading bigger files
 
@@ -124,13 +124,13 @@ end
         
         # add data to the global dataset if it's not there
         if !haskey(g_datasets, :ch4)
-            g_datasets[:ch4] = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_ch4_emissions.csv")) |> DataFrame
+            g_datasets[:ch4] = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_ch4_emissions.csv")) |> DataFrame
         end
         if !haskey(g_datasets, :n2o)
-            g_datasets[:n2o] = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_n2o_emissions.csv")) |> DataFrame
+            g_datasets[:n2o] = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_n2o_emissions.csv")) |> DataFrame
         end
         if !haskey(g_datasets, :co2)
-            g_datasets[:co2] = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_co2_emissions.csv")) |> DataFrame
+            g_datasets[:co2] = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_co2_emissions.csv")) |> DataFrame
         end
 
         # fill in the variales
@@ -142,7 +142,7 @@ end
         # Population and GDP 1990 Values
 
         if !haskey(g_datasets, :ypc1990)
-            g_datasets[:ypc1990] = load(joinpath(datadep"rffsps_v2", "ypc1990", "rffsp_ypc1990.csv")) |> 
+            g_datasets[:ypc1990] = load(joinpath(datadep"rffsps_v3", "ypc1990", "rffsp_ypc1990.csv")) |> 
                 DataFrame |> 
                 i -> insertcols!(i, :sample => 1:10_000) |> 
                 i -> stack(i, Not(:sample)) |> 

--- a/test/test_SPs.jl
+++ b/test/test_SPs.jl
@@ -59,11 +59,11 @@ run(m)
 
 # check emissions
 
-ch4 = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_ch4_emissions.csv")) |> 
+ch4 = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_ch4_emissions.csv")) |> 
     DataFrame |> @filter(_.year in collect(2020:2300)) |> @filter(_.sample == id) |> DataFrame
-n2o = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_n2o_emissions.csv")) |> 
+n2o = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_n2o_emissions.csv")) |> 
     DataFrame |> @filter(_.year in collect(2020:2300)) |> @filter(_.sample == id) |> DataFrame
-co2 = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_co2_emissions.csv")) |> 
+co2 = load(joinpath(datadep"rffsps_v3", "emissions", "rffsp_co2_emissions.csv")) |> 
     DataFrame |> @filter(_.year in collect(2020:2300)) |> @filter(_.sample == id) |> DataFrame
 
 @test m[:SPs, :co2_emissions][findfirst(i -> i == 2020, collect(2020:2300)):end] ≈ co2.value atol = 1e-9
@@ -72,7 +72,7 @@ co2 = load(joinpath(datadep"rffsps_v2", "emissions", "rffsp_co2_emissions.csv"))
 
 # check socioeconomics
 
-t = Arrow.Table(joinpath(datadep"rffsps_v2", "pop_income", "rffsp_pop_income_run_$id.feather"))
+t = Arrow.Table(joinpath(datadep"rffsps_v3", "pop_income", "rffsp_pop_income_run_$id.feather"))
 socio_df = DataFrame(   :Year => copy(t.Year), 
                         :Country => copy(t.Country), 
                         :Pop => copy(t.Pop), 
@@ -112,7 +112,7 @@ deathrate_trajectory_id = convert(Int64, pop_trajectory_key[id])
         
 # Load Feather File
 original_years = collect(2023:5:2300)
-t = Arrow.Table(joinpath(datadep"rffsps_v2", "death_rates", "rffsp_death_rates_run_$(deathrate_trajectory_id).feather"))
+t = Arrow.Table(joinpath(datadep"rffsps_v3", "death_rates", "rffsp_death_rates_run_$(deathrate_trajectory_id).feather"))
 deathrate_df = DataFrame(:Year => copy(t.Year), 
                         :Country => copy(t.ISO3), 
                         :DeathRate => copy(t.DeathRate)
@@ -148,7 +148,7 @@ population1990 = load(joinpath(@__DIR__, "..", "data", "population1990.csv")) |>
 
 # # check gdp 1990
 
-ypc1990 = load(joinpath(datadep"rffsps_v2", "ypc1990", "rffsp_ypc1990.csv")) |> 
+ypc1990 = load(joinpath(datadep"rffsps_v3", "ypc1990", "rffsp_ypc1990.csv")) |> 
                 DataFrame |> 
                 i -> insertcols!(i, :sample => 1:10_000) |> 
                 i -> stack(i, Not(:sample)) |> 


### PR DESCRIPTION
With this update I started versioning the name so that we don't run into problems there. I also renamed all the files in the archives to a more consistent naming schema.

Oh, and this picks up the new spline based emissions, and it also (for the first time) uses the feather files that Jordan produced, rather than the one that I converted.

EDIT: But this actually doesn't work because the new emission files are in wide rather than long format. @jmwingenroth could you produce these files in the same format that we used in the previous iteration?