### PR TITLE
Replace `stack` with `DataFrames.stack`

### DIFF
--- a/src/components/SPs.jl
+++ b/src/components/SPs.jl
@@ -163,7 +163,7 @@ end
             g_datasets[:ypc1990] = load(joinpath(datadep"rffsps_v5", "ypc1990", "rffsp_ypc1990.csv")) |> 
                 DataFrame |> 
                 i -> insertcols!(i, :sample => 1:10_000) |> 
-                i -> stack(i, Not(:sample)) |> 
+                i -> DataFrames.stack(i, Not(:sample)) |> 
                 i -> rename!(i, [:sample, :country, :value]) |> 
                 @groupby(_.sample) |>
                 @orderby(key(_)) |>

--- a/test/test_API.jl
+++ b/test/test_API.jl
@@ -118,7 +118,7 @@ population1990 = load(joinpath(@__DIR__, "..", "data", "population1990.csv")) |>
 ypc1990 = load(joinpath(datadep"rffsps_v5", "ypc1990", "rffsp_ypc1990.csv")) |> 
                 DataFrame |> 
                 i -> insertcols!(i, :sample => 1:10_000) |> 
-                i -> stack(i, Not(:sample)) |> 
+                i -> DataFrames.stack(i, Not(:sample)) |> 
                 DataFrame |> 
                 @filter(_.sample == id) |>
                 DataFrame |>

--- a/test/test_SPs.jl
+++ b/test/test_SPs.jl
@@ -159,7 +159,7 @@ population1990 = load(joinpath(@__DIR__, "..", "data", "population1990.csv")) |>
 ypc1990 = load(joinpath(datadep"rffsps_v5", "ypc1990", "rffsp_ypc1990.csv")) |> 
                 DataFrame |> 
                 i -> insertcols!(i, :sample => 1:10_000) |> 
-                i -> stack(i, Not(:sample)) |> 
+                i -> DataFrames.stack(i, Not(:sample)) |> 
                 DataFrame |> 
                 @filter(_.sample == id) |>
                 DataFrame |>


### PR DESCRIPTION
Julia 1.9 exports a `stack` function which conflicts with `DataFrames.stack`.